### PR TITLE
Fixes & updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Typed Validator [![Build Status](https://travis-ci.org/typed-typings/npm-validator.svg?branch=master)](https://travis-ci.org/typed-typings/npm-validator)
+# Typed Validator [![Build Status][travis-image]][travis-url] 
 
-The type definition for [validator](https://github.com/chriso/validator.js).
+Type definitions for [validator](https://github.com/chriso/validator.js).
 
 # LICENSE
 MIT
+
+[travis-url]: https://travis-ci.org/types/npm-validator/
+[travis-image]: http://img.shields.io/travis/types/npm-validator.svg

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,9 @@ declare namespace validator {
     // check if the string is a valid currency amount.
     isCurrency(str: string, options?: IsCurrencyOptions): boolean;
 
+    // check if the string is a data uri format (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs)
+    isDataURI(str: string): boolean;
+
     // check if the string is a date.
     isDate(str: string): boolean;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -187,9 +187,6 @@ declare namespace validator {
     // convert the input to an integer, or NaN if the input is not an integer.
     toInt(input: any, radix?: number): number; // number or NaN
 
-    // convert the input to a string.
-    toString(input: any): string;
-
     // trim characters (whitespace by default) from both sides of the input.
     trim(input: any, chars?: string): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare namespace validator {
     isBase64(str: string): boolean;
 
     // check if the string is a date that's before the specified date.
-    isBefore(str: string, date?: Date): boolean;
+    isBefore(str: string, date?: string): boolean;
 
     // check if a string is a boolean.
     isBoolean(str: string): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare namespace validator {
     equals(str: string, comparison: any): boolean;
 
     // check if the string is a date that's after the specified date (defaults to now).
-    isAfter(str: string, date?: Date): boolean;
+    isAfter(str: string, date?: string): boolean;
 
     // check if the string contains only letters (a-zA-Z).
     isAlpha(str: string): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ declare namespace validator {
     isWhitelisted(str: string, chars: string|string[]): boolean;
 
     // check if string matches the pattern.
-    matches(str: string, pattern: any, modifiers?: string): boolean;
+    matches(str: string, pattern: RegExp|string, modifiers?: string): boolean;
 
     /**************
      * Sanitizers *

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,8 +109,11 @@ declare namespace validator {
     // check if the string is a MAC address.
     isMACAddress(str: string): boolean;
 
-    // check if the string is a mobile phone number, (locale is one of ['zh-CN', 'zh-TW', 'en-ZA', 'en-AU', 'en-HK',
-    // 'pt-PT', 'fr-FR', 'el-GR', 'en-GB', 'en-US', 'en-ZM', 'ru-RU', 'nb-NO', 'nn-NO', 'vi-VN', 'en-NZ', 'en-IN']).
+    // check if the string is a mobile phone number, (locale is one of
+    // ['ar-DZ', 'ar-SA', 'ar-SY', 'cs-CZ', 'de-DE', 'da-DK', 'el-GR', 'en-AU', 'en-GB', 'en-HK',
+    // 'en-IN', 'en-NZ', 'en-US', 'en-CA', 'en-ZA', 'en-ZM', 'es-ES', 'fi-FI', 'fr-FR', 'hu-HU',
+    // 'it-IT', 'ja-JP', 'ms-MY', 'nb-NO', 'nn-NO', 'pl-PL', 'pt-PT', 'ru-RU', 'sr-RS', 'tr-TR',
+    // 'vi-VN', 'zh-CN', 'zh-TW']).
     isMobilePhone(str: string, locale: string): boolean;
 
     // check if the string is a valid hex-encoded representation of a MongoDB ObjectId

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,8 +135,8 @@ declare namespace validator {
     // check if the string is an URL.
     isURL(str: string, options?: IsURLOptions): boolean;
 
-    // check if the string is a UUID (version 3, 4 or 5).
-    isUUID(str: string, version?: number): boolean;
+    // check if the string is a UUID. Must be one of ['3', '4', '5', 'all'], default is all.
+    isUUID(str: string, version?: string|number): boolean;
 
     // check if the string is uppercase.
     isUppercase(str: string): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -167,6 +167,9 @@ declare namespace validator {
     // replace <, >, &, ', " and / with HTML entities.
     escape(input: string): string;
 
+    // replaces HTML encoded entities with <, >, &, ', " and /.
+    unescape(input: string): string;
+
     // trim characters from the left-side of the input.
     ltrim(input: any, chars?: string): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,9 @@ declare namespace validator {
     // check if the string is a MAC address.
     isMACAddress(str: string): boolean;
 
+    // check if the string is a MD5 hash.
+    isMD5(str: string): boolean;
+
     // check if the string is a mobile phone number, (locale is one of
     // ['ar-DZ', 'ar-SA', 'ar-SY', 'cs-CZ', 'de-DE', 'da-DK', 'el-GR', 'en-AU', 'en-GB', 'en-HK',
     // 'en-IN', 'en-NZ', 'en-US', 'en-CA', 'en-ZA', 'en-ZM', 'es-ES', 'fi-FI', 'fr-FR', 'hu-HU',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "postinstall": "typings install",
-    "build": "tsc -p . && typings bundle -o dist",
+    "build": "tsc -p . && typings bundle -o dist/main.d.ts",
     "test": "tsc -p test",
     "build+test": "npm run build && npm run test"
   },
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/typed-typings/npm-validator#readme",
   "devDependencies": {
     "typescript": "^1.8.10",
-    "typings": "^0.7.12"
+    "typings": "^1.3.3"
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -40,6 +40,8 @@ let any: any;
   result = validator.isCurrency('sample');
   result = validator.isCurrency('sample', isCurrencyOptions);
 
+  result = validator.isDataURI('sample');
+
   result = validator.isDate('sample');
 
   result = validator.isDecimal('sample');

--- a/test/index.ts
+++ b/test/index.ts
@@ -139,6 +139,8 @@ let any: any;
 
   result = validator.escape('sample');
 
+  result = validator.unescape('sample');
+
   result = validator.ltrim('sample');
   result = validator.ltrim('sample', ' ');
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -111,6 +111,7 @@ let any: any;
 
   result = validator.isUUID('sample');
   result = validator.isUUID('sample', 5);
+  result = validator.isUUID('sample', 'all');
 
   result = validator.isUppercase('sample');
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -95,6 +95,8 @@ let any: any;
 
   result = validator.isMACAddress('sample');
 
+  result = validator.isMD5('sample');
+
   result = validator.isMobilePhone('sample', 'en-US');
 
   result = validator.isMongoId('sample');

--- a/test/index.ts
+++ b/test/index.ts
@@ -174,8 +174,6 @@ let any: any;
 {
   let result: string;
 
-  result = validator.toString(any);
-
   result = validator.trim('sample');
   result = validator.trim('sample', ' ');
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,7 +25,7 @@ let any: any;
   result = validator.isBase64('sample');
 
   result = validator.isBefore('sample');
-  result = validator.isBefore('sample', new Date());
+  result = validator.isBefore('sample', new Date().toString());
 
   result = validator.isBoolean('sample');
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -14,7 +14,7 @@ let any: any;
   result = validator.equals('sample', 'sample');
 
   result = validator.isAfter('sample');
-  result = validator.isAfter('sample', new Date());
+  result = validator.isAfter('sample', new Date().toString());
 
   result = validator.isAlpha('sample');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,11 @@
     "module": "commonjs"
   },
   "filesGlob": [
-    "./typings/main.d.ts",
+    "./typings/index.d.ts",
     "./*.d.ts"
   ],
   "files": [
-    "./typings/main.d.ts",
+    "./typings/index.d.ts",
     "./index.d.ts"
   ],
   "atom": {


### PR DESCRIPTION
- Fixed `isAfter` and `isBefore`: The 2nd arg should be a `string`
- Updated documentation for `isMobilePhone`
- Upgraded `typings` tool
- Update the API to the latest version [v5.6.0](https://github.com/chriso/validator.js/blob/5.6.0/README.md#validators):
  - Added `isDataURI`, `isMD5` validators and `unescape` sanitizer
- removed `toString`
