### PR TITLE
Add version to package.json to solve problem with NPM 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@types/validator",
+  "version": "5.7.0",
   "private": true,
   "scripts": {
     "postinstall": "typings install",


### PR DESCRIPTION
NPM 3 has issues when trying to install packages from git that have no `version`.