### PR TITLE
Update types to match validator 7.0.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for validator.js v5.7.0
+// Type definitions for validator.js v7.0.0
 // Project: https://github.com/chriso/validator.js
 // Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>
 
@@ -54,9 +54,6 @@ declare namespace validator {
 
     // check if the string is a data uri format (https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs)
     isDataURI(str: string): boolean;
-
-    // check if the string is a date.
-    isDate(str: string): boolean;
 
     // check if the string represents a decimal number, such as 0.1, .3, 1.1, 1.00003, 4.0, etc.
     isDecimal(str: string): boolean;
@@ -136,7 +133,7 @@ declare namespace validator {
     isMultibyte(str: string): boolean;
 
     // check if the string is null.
-    isNull(str: string): boolean;
+    isEmpty(str: string): boolean;
 
     // check if the string contains only numbers.
     isNumeric(str: string): boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@types/validator",
-  "version": "5.7.0",
+  "version": "7.0.0",
   "private": true,
   "scripts": {
     "build": "tsc -p . && typings bundle -o dist/main.d.ts",

--- a/test/index.ts
+++ b/test/index.ts
@@ -44,8 +44,6 @@ let any: any;
 
   result = validator.isDataURI('sample');
 
-  result = validator.isDate('sample');
-
   result = validator.isDecimal('sample');
 
   result = validator.isDivisibleBy('sample', 2);
@@ -105,7 +103,7 @@ let any: any;
 
   result = validator.isMultibyte('sample');
 
-  result = validator.isNull('sample');
+  result = validator.isEmpty('sample');
 
   result = validator.isNumeric('sample');
 

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,6 @@
 {
   "name": "validator",
   "main": "index.d.ts",
-  "version": "5.7.0",
+  "version": "7.0.0",
   "dependencies": {}
 }


### PR DESCRIPTION
- Remove isDate()
- Renamed isNull() to isEmpty() (https://github.com/chriso/validator.js/issues/574)